### PR TITLE
Add Migrated Event

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -53,7 +53,13 @@ struct MigrationCallbackData {
 
 ## Events
 
-TODO
+```c
+event Migrated(
+  address indexed user,
+  Collateral[] collateral,
+  uint256 repayAmount,
+  uint256 borrowAmountWithFee)
+```
 
 ## Contract Functions
 
@@ -179,6 +185,7 @@ This function may only be called during a migration command. We ensure this by m
     - **CALL** `comet.supplyTo(user, cToken.underlying(), cToken.underlying().balanceOf(address(this)))`
   - **CALL** `comet.withdrawFrom(user, address(this), borrowToken, borrowAmountWithFee)`
   - **CALL** `borrowToken.transfer(address(uniswapLiquidityPool), borrowAmountWithFee)`
+  - **EMIT** `Migrated(user, collateral, repayAmount, borrowAmountWithFee)`
 
 ### Sweep Function
 

--- a/src/Comet_V2_Migrator.sol
+++ b/src/Comet_V2_Migrator.sol
@@ -20,7 +20,11 @@ contract Comet_V2_Migrator is IUniswapV3FlashCallback {
   error CTokenTransferFailure();
 
   /** Events **/
-  // event Absorb(address indexed initiator, address[] accounts);
+  event Migrated(
+    address indexed user,
+    Collateral[] collateral,
+    uint256 repayAmount,
+    uint256 borrowAmountWithFee);
 
   /// @notice Represents a given amount of collateral to migrate.
   struct Collateral {
@@ -238,6 +242,9 @@ contract Comet_V2_Migrator is IUniswapV3FlashCallback {
 
     // **CALL** `borrowToken.transfer(address(uniswapLiquidityPool), borrowAmountWithFee)`
     borrowToken.transfer(address(uniswapLiquidityPool), borrowAmountWithFee);
+
+    // **EMIT** `Migrated(user, collateral, repayAmount, borrowAmountWithFee)`
+    emit Migrated(migrationData.user, migrationData.collateral, migrationData.repayAmount, borrowAmountWithFee);
   }
 
   /**

--- a/test/Comet_V2_Migrator.t.sol
+++ b/test/Comet_V2_Migrator.t.sol
@@ -8,6 +8,12 @@ import "./MainnetConstants.t.sol";
 import "./Positor.t.sol";
 
 contract ContractTest is Positor {
+    event Migrated(
+        address indexed user,
+        Comet_V2_Migrator.Collateral[] collateral,
+        uint256 repayAmount,
+        uint256 borrowAmountWithFee);
+
     address public constant borrower = address(0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266);
 
     function testMigrateSimpleUniPosition() public {
@@ -37,6 +43,11 @@ contract ContractTest is Positor {
         vm.startPrank(borrower);
         cUNI.approve(address(migrator), type(uint256).max);
         comet.allow(address(migrator), true);
+
+        // Check event
+        vm.expectEmit(true, false, false, true);
+        emit Migrated(borrower, collateral, 600e6, 600e6 * 1.0001);
+
         migrator.migrate(collateral, 600e6);
 
         // Check v2 balances


### PR DESCRIPTION
This patch adds the `Migrated` event, which is the only relevant event for migration. We add a test to make sure it is properly emitted.