### PR TITLE
Fill in Deployments

### DIFF
--- a/script/Playground.s.sol
+++ b/script/Playground.s.sol
@@ -4,26 +4,11 @@ pragma solidity ^0.8.13;
 import "forge-std/Script.sol";
 import "../src/Comet_V2_Migrator.sol";
 import "forge-std/Test.sol";
-import "../src/vendor/@uniswap/v3-periphery/contracts/interfaces/ISwapRouter.sol";
+import "../test/MainnetConstants.t.sol";
+import "forge-std/console2.sol";
 
-interface Comptroller {
-    function enterMarkets(address[] memory cTokens) external returns (uint[] memory);
-}
-
-contract Playground is Script, Test {
-    Comet public constant comet = Comet(0xc3d688B66703497DAA19211EEdff47f25384cdc3);
-    IERC20 public constant usdc = IERC20(0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48);
-    CErc20 public constant cUSDC = CErc20(0x39AA39c021dfbaE8faC545936693aC917d5E7563);
-    CErc20 public constant cUNI = CErc20(0x35A18000230DA775CAc24873d00Ff85BccdeD550);
-    CTokenLike public constant cETH = CTokenLike(0x4Ddc2D193948926D02f9B1fE9e1daa0718270ED5);
-    IUniswapV3Pool public constant pool_DAI_USDC = IUniswapV3Pool(0x5777d92f208679DB4b9778590Fa3CAB3aC9e2168);
-    address payable public constant sweepee = payable(0x6d903f6003cca6255D85CcA4D3B5E5146dC33925);
-    address public constant uniswapFactory = address(0x1F98431c8aD98523631AE4a59f267346ea31F984);
-    ISwapRouter public constant swapRouter = ISwapRouter(0xE592427A0AEce92De3Edee1F18E0157C05861564);
-    IERC20 public constant uni = IERC20(0x1f9840a85d5aF5bf1D1762F925BDADdC4201F984);
-    IWETH9 public constant weth = IWETH9(0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2);
+contract Playground is Script, Test, MainnetConstants {
     address public constant caller = address(0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266);
-    Comptroller public constant comptroller = Comptroller(0x3d9819210A31b4961b30EF54bE2aeD79B9c9Cd3B);
 
     function setUp() public {}
 

--- a/script/goerli/deploy_migrator.sh
+++ b/script/goerli/deploy_migrator.sh
@@ -20,27 +20,25 @@ else
   etherscan_args=""
 fi
 
-# Constructor Variables from
+# Constructor Variables
 #
 # Comet_V2_Migrator::constructor(
-#   Comet comet_,
-#   CErc20 borrowCToken_,
-#   IUniswapV3Pool uniswapLiquidityPool_,
-#   IERC20[] memory collateralTokens_,
-#   address sweepee_,
-#   address _factory, // TODO
-#   address _WETH9 // TODO
+#   comet_ :: The Comet Ethereum mainnet USDC contract.
+#   borrowCToken_ :: The Compound II market for the borrowed token (e.g. `cUSDC`).
+#   cETH_ :: The address of the `cETH` token.
+#   weth_ :: The address of the `WETH9` token.
+#   uniswapLiquidityPool_ :: The Uniswap pool used by this contract to source liquidity (i.e. flash loans).
+#   sweepee_ :: Sweep excess tokens to this address.
 # )
 #
 comet="0x"
 borrowCToken="0x"
+cETH="0x"
+weth="0x"
 uniswapLiquidityPool="0x"
-collateralTokens="[]"
 sweepee="0x"
-factory="0x"
-weth9="0x"
 
-echo forge create \
+forge create \
   $rpc_args \
   $etherscan_args \
   $wallet_args \
@@ -49,8 +47,7 @@ echo forge create \
   --constructor-args \
     "$comet" \
     "$borrowCToken" \
+    "$cETH" \
+    "$weth" \
     "$uniswapLiquidityPool" \
-    "$collateralTokens" \
-    "$sweepee" \
-    "$factory" \
-    "$weth9"
+    "$sweepee"

--- a/script/mainnet/deploy_migrator.sh
+++ b/script/mainnet/deploy_migrator.sh
@@ -20,27 +20,25 @@ else
   etherscan_args=""
 fi
 
-# Constructor Variables from
+# Constructor Variables
 #
 # Comet_V2_Migrator::constructor(
-#   Comet comet_,
-#   CErc20 borrowCToken_,
-#   IUniswapV3Pool uniswapLiquidityPool_,
-#   IERC20[] memory collateralTokens_,
-#   address sweepee_,
-#   address _factory, // TODO
-#   address _WETH9 // TODO
+#   comet_ :: The Comet Ethereum mainnet USDC contract.
+#   borrowCToken_ :: The Compound II market for the borrowed token (e.g. `cUSDC`).
+#   cETH_ :: The address of the `cETH` token.
+#   weth_ :: The address of the `WETH9` token.
+#   uniswapLiquidityPool_ :: The Uniswap pool used by this contract to source liquidity (i.e. flash loans).
+#   sweepee_ :: Sweep excess tokens to this address.
 # )
 #
 comet="0x"
 borrowCToken="0x"
+cETH="0x"
+weth="0x"
 uniswapLiquidityPool="0x"
-collateralTokens="[]"
 sweepee="0x"
-factory="0x"
-weth9="0x"
 
-echo forge create \
+forge create \
   $rpc_args \
   $etherscan_args \
   $wallet_args \
@@ -49,8 +47,7 @@ echo forge create \
   --constructor-args \
     "$comet" \
     "$borrowCToken" \
+    "$cETH" \
+    "$weth" \
     "$uniswapLiquidityPool" \
-    "$collateralTokens" \
-    "$sweepee" \
-    "$factory" \
-    "$weth9"
+    "$sweepee"

--- a/test/MainnetConstants.t.sol
+++ b/test/MainnetConstants.t.sol
@@ -2,6 +2,7 @@
 pragma solidity ^0.8.13;
 
 import "../src/Comet_V2_Migrator.sol";
+import "../src/vendor/@uniswap/v3-periphery/contracts/interfaces/ISwapRouter.sol";
 
 interface Comptroller {
     function enterMarkets(address[] memory cTokens) external returns (uint[] memory);
@@ -21,4 +22,5 @@ contract MainnetConstants {
     address public constant cHolderUni = address(0x39d8014b4F40d2CBC441137011d32023f4f1fd87);
     address public constant cHolderEth = address(0xe84A061897afc2e7fF5FB7e3686717C528617487);
     Comptroller public constant comptroller = Comptroller(0x3d9819210A31b4961b30EF54bE2aeD79B9c9Cd3B);
+    ISwapRouter public constant swapRouter = ISwapRouter(0xE592427A0AEce92De3Edee1F18E0157C05861564);
 }


### PR DESCRIPTION
This patch starts to fill in the deployment scripts with the more production-ready constructor to Comet v2 Migrator. Additionally, we fix some minor issues with the playground.