### PR TITLE
Try to reduce RPC requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,21 @@ TODO
 
 ## Embedding
 
-TODO: Describe how to test as an embedded Webb3 extension.
+You can run [Webb3](https://github.com/compound-finance/webb3) locally with a local version of the extension running. First, run this extension:
+
+```sh
+# in comet_v2_migrator/
+yarn web:dev
+```
+
+Take a note of the port (it should be 5183). Then run Webb3 with the following env var set:
+
+```sh
+# in webb3/
+VITE_COMET_V2_MIGRATOR_SOURCE=http://localhost:5183/embedded.html yarn dev
+```
+
+When the extension loads at [http://localhost:5173](http://localhost:5173), it should load this local extension, instead of the production version.
 
 ## Contributing
 

--- a/web/lib/useWeb3.ts
+++ b/web/lib/useWeb3.ts
@@ -1,9 +1,9 @@
 import { useMemo } from 'react';
 import { sendWeb3 } from './RPC';
 import { SendRPC } from './useRPC';
-import { JsonRpcProvider } from '@ethersproject/providers';
+import { StaticJsonRpcProvider } from '@ethersproject/providers';
 
-class RpcWeb3Provider extends JsonRpcProvider {
+class RpcWeb3Provider extends StaticJsonRpcProvider  {
   sendRPC: SendRPC;
 
   constructor(sendRPC: SendRPC) {
@@ -12,8 +12,17 @@ class RpcWeb3Provider extends JsonRpcProvider {
   }
 
   send(method: string, params: Array<any>): Promise<any> {
+    const cache = ["eth_chainId", "eth_blockNumber"].indexOf(method) >= 0;
+    if (cache && this._cache[method]) {
+      return this._cache[method];
+    }
     let res = sendWeb3(this.sendRPC, method, params);
-    res.then((r) => console.log("rpc response", method, params, r));
+    if (cache) {
+      this._cache[method] = res;
+      setTimeout(() => {
+        this._cache[method] = null as any;
+      }, 0);
+    }
     return res;
   }
 }


### PR DESCRIPTION
This patch tries to reduce RPC requests - ensuring our hooks aren't excessively causing calls -- and also using a static RPC provider and the same caching Ethers uses internally. The code was effectively making 3 requests for every request, so this reduces that load.