### PR TITLE
Handle Ext Messages and Set Theme

### DIFF
--- a/web/EmbeddedApp.tsx
+++ b/web/EmbeddedApp.tsx
@@ -6,10 +6,10 @@ import { useRPC } from './lib/useRPC';
 import { useWeb3 } from './lib/useWeb3';
 
 function EmbeddedApp() {
-  let sendRPC = useRPC();
-  let web3 = useWeb3(sendRPC);
+  let rpc = useRPC();
+  let web3 = useWeb3(rpc.sendRPC);
 
-  return <App sendRPC={sendRPC} web3={web3} />
+  return <App rpc={rpc} web3={web3} />
 }
 
 ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(

--- a/web/lib/MessageTypes.ts
+++ b/web/lib/MessageTypes.ts
@@ -1,12 +1,26 @@
 import { TransactionResponse } from '@ethersproject/providers';
 
 export type InMessage =
-  { type: 'read', to: string, data: string } |
-  { type: 'write', to: string, data: string } |
-  { type: 'sendWeb3', method: string, params: string[] };
+  | { type: 'read'; to: string; data: string }
+  | { type: 'write'; to: string; data: string }
+  | { type: 'sendWeb3'; method: string; params: string[] }
+  | { type: 'getTheme'; };
 
-export type OutMessage<InMessage> =
-  InMessage extends { type: 'read' } ? { type: 'read', data: string } :
-  InMessage extends { type: 'write' } ? { type: 'write', data: TransactionResponse } :
-  InMessage extends { type: 'sendWeb3' } ? { type: 'sendWeb3', data: any } :
-  null;
+export type OutMessage<InMessage> = InMessage extends { type: 'read' }
+  ? { type: 'read'; data: string }
+  : InMessage extends { type: 'write' }
+  ? { type: 'write'; data: TransactionResponse }
+  : InMessage extends { type: 'sendWeb3' }
+  ? { type: 'sendWeb3'; data: any }
+  : InMessage extends { type: 'getTheme' }
+  ? { type: 'setTheme'; theme: 'Dark' | 'Light' }
+  : null;
+
+export type ExtMessage =
+  { type: 'setTheme', theme: 'Dark' | 'Light' };
+
+type ExtMessageConfig<ExtMessage extends { type: string }> = {
+    [E in ExtMessage as E["type"]]?: (msg: E) => void;
+};
+
+export type ExtMessageHandler = ExtMessageConfig<ExtMessage>;


### PR DESCRIPTION
This patch adds a basic set-up for handling inbound messages that aren't RPC calls in an extension. For instance, the Webb3 app will now send a message to an extension when the theme changes, so the extension can sync on light or dark themes. This will also be a basis for proactively telling an extension that the user's account or network has changed, so we don't need to wait for a poll in the extension to learn that information.