### PR TITLE
Rename Comet_V2_Migrator to CometMigrator

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,16 +53,16 @@ To run this in embedded mode (see Embedding below), you should run the following
 
 ```sh
 # in webb3/
-VITE_WEBB3_MAINNET_URL=http://localhost:8545 VITE_COMET_V2_MIGRATOR_SOURCE=http://localhost:5183/embedded.html yarn dev
+VITE_WEBB3_MAINNET_URL=http://localhost:8545 VITE_COMET_MIGRATOR_SOURCE=http://localhost:5183/embedded.html yarn dev
 ```
 
-## Compound v2 Migrator Operator
+## Comet Migrator Operator
 
-The Compound v2 Migrator Operator code lives in `src/Comet_V2_Migrator.sol`. Note: we use a large amount of vendoring to pull in Uniswap, Compound v2 and Compound v3 source files. We use [vendoza](https://github.com/hayesgm/vendoza) to track the diffs.
+The Comet Migrator Operator code lives in `src/CometMigrator.sol`. Note: we use a large amount of vendoring to pull in Uniswap, Compound v2 and Compound v3 source files. We use [vendoza](https://github.com/hayesgm/vendoza) to track the diffs.
 
-The [Compound v2 Migrator Spec](./SPEC.md) contains the full spec on the specifics of the migrator code.
+The [Comet Migrator Spec](./SPEC.md) contains the full spec on the specifics of the migrator code.
 
-Note: `script/copy-abi.sh` is currently used to sync the ABI from the `Comet_V2_Migrator.sol` to `abis/Comet_V2_Migrator.ts` for use in the Extension. We may want to find a simpler system for this at some point.
+Note: `script/copy-abi.sh` is currently used to sync the ABI from the `CometMigrator.sol` to `abis/CometMigrator.ts` for use in the Extension. We may want to find a simpler system for this at some point.
 
 ## Deploying
 
@@ -99,7 +99,7 @@ TODO
 You can run [Webb3](https://github.com/compound-finance/webb3) locally with a local version of the extension running. First, run this extension:
 
 ```sh
-# in comet_v2_migrator/
+# in comet-migrator/
 yarn web:dev
 ```
 
@@ -107,7 +107,7 @@ Take a note of the port (it should be 5183). Then run Webb3 with the following e
 
 ```sh
 # in webb3/
-VITE_COMET_V2_MIGRATOR_SOURCE=http://localhost:5183/embedded.html yarn dev
+VITE_COMET_MIGRATOR_SOURCE=http://localhost:5183/embedded.html yarn dev
 ```
 
 When the extension loads at [http://localhost:5173](http://localhost:5173), it should load this local extension, instead of the production version.
@@ -116,7 +116,7 @@ If you are using the playground, you should also make sure Webb3 uses that URL f
 
 ```sh
 # in webb3/
-VITE_WEBB3_MAINNET_URL=http://localhost:8545 VITE_COMET_V2_MIGRATOR_SOURCE=http://localhost:5183/embedded.html yarn dev
+VITE_WEBB3_MAINNET_URL=http://localhost:8545 VITE_COMET_MIGRATOR_SOURCE=http://localhost:5183/embedded.html yarn dev
 ```
 
 ## Contributing

--- a/SPEC.md
+++ b/SPEC.md
@@ -1,10 +1,10 @@
-# Comet V2 Migrator
+# Comet Migrator
 
-The CToken Migrator is a set of contracts to transfer a positions from [Compound II](https://v2-app.compound.finance) to [Compound III](https://v3-app.compound.finance).
+The Comet Migrator is a set of contracts to transfer a positions from [Compound II](https://v2-app.compound.finance) and other DeFi protocols to [Compound III](https://v3-app.compound.finance).
 
-# Migration Spec Comet_V2_Migrator
+# Migration Spec CometMigrator
 
-The Comet_V2_Migrator contract is used to transfer a position where a user is borrowing a token from Compound II to a position where that user is now borrowing USDC in Compound III. We use a flash loan to faciliate the transition, but there are no swaps otherwise involved in this transfer. Positions can be transferred in whole or in part.
+The CometMigrator contract is used to transfer a position where a user is borrowing a token from Compound II to a position where that user is now borrowing USDC in Compound III. We use a flash loan to faciliate the transition, but there are no swaps otherwise involved in this transfer. Positions can be transferred in whole or in part.
 
 ## Knobs
 
@@ -78,7 +78,7 @@ This function describes the initialization process for this contract. We set the
 
 #### Function Spec
 
-`function Comet_V2_Migrator(Comet comet_, CToken borrowCToken_, CToken cETH_, WETH9 weth, UniswapV3Pool uniswapLiquidityPool_, address sweepee_) external`
+`function CometMigrator(Comet comet_, CToken borrowCToken_, CToken cETH_, WETH9 weth, UniswapV3Pool uniswapLiquidityPool_, address sweepee_) external`
 
  * **WRITE IMMUTABLE** `comet = comet_`
  * **WRITE IMMUTABLE** `borrowCToken = borrowCToken_`

--- a/abis/CometMigrator.ts
+++ b/abis/CometMigrator.ts
@@ -101,7 +101,7 @@ export default [
           }
         ],
         "indexed": false,
-        "internalType": "struct Comet_V2_Migrator.Collateral[]",
+        "internalType": "struct CometMigrator.Collateral[]",
         "name": "collateral",
         "type": "tuple[]"
       },
@@ -220,7 +220,7 @@ export default [
             "type": "uint256"
           }
         ],
-        "internalType": "struct Comet_V2_Migrator.Collateral[]",
+        "internalType": "struct CometMigrator.Collateral[]",
         "name": "collateral",
         "type": "tuple[]"
       },

--- a/embedded.html
+++ b/embedded.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
-    <title>Compound II to Compound III Migrator</title>
+    <title>Compound III Migrator</title>
     <meta
       name="description"
       content=""

--- a/index.html
+++ b/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
-    <title>Compound II to Compound III Migrator</title>
+    <title>Compound III Migrator</title>
     <meta
       name="description"
       content=""

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "comet_v2_migator",
+  "name": "@compound-finance/comet_migrator",
   "version": "0.1.0",
   "type": "module",
   "private": true,
@@ -8,6 +8,7 @@
     "web:build": "tsc && vite build",
     "web:preview": "vite preview",
     "web:test": "jest",
+    "forge:build": "forge build",
     "forge:test": "script/test.sh",
     "forge:lint": "solhint '{src,script,test}/**/*.sol'",
     "forge:playground": "script/playground.sh",

--- a/script/Playground.s.sol
+++ b/script/Playground.s.sol
@@ -2,7 +2,7 @@
 pragma solidity ^0.8.13;
 
 import "forge-std/Script.sol";
-import "../src/Comet_V2_Migrator.sol";
+import "../src/CometMigrator.sol";
 import "forge-std/Test.sol";
 import "../test/MainnetConstants.t.sol";
 import "forge-std/console2.sol";
@@ -15,9 +15,9 @@ contract Playground is Script, Test, MainnetConstants {
     function run() public {
         vm.startBroadcast();
 
-        console.log("Deploying Comet v2 Migrator");
-        Comet_V2_Migrator migrator = deployCometV2Migrator();
-        console.log("Deployed Comet v2 Migrator", address(migrator));
+        console.log("Deploying Comet Migrator");
+        CometMigrator migrator = deployCometMigrator();
+        console.log("Deployed Comet Migrator", address(migrator));
 
         console.log("Wrapping WETH");
         weth.deposit{value: 50 ether}();
@@ -51,8 +51,8 @@ contract Playground is Script, Test, MainnetConstants {
         console.log("Proceed.");
     }
 
-    function deployCometV2Migrator() internal returns (Comet_V2_Migrator) {
-        return new Comet_V2_Migrator(
+    function deployCometMigrator() internal returns (CometMigrator) {
+        return new CometMigrator(
             comet,
             cUSDC,
             cETH,

--- a/script/copy-abi.sh
+++ b/script/copy-abi.sh
@@ -2,7 +2,7 @@
 
 set -x
 
-out_file="./abis/Comet_V2_Migrator.ts"
+out_file="./abis/CometMigrator.ts"
 echo -n "export default " > "$out_file"
-cat ./out/Comet_V2_Migrator.sol/Comet_V2_Migrator.json | jq -rj '.abi' >> "$out_file"
+cat ./out/CometMigrator.sol/CometMigrator.json | jq -rj '.abi' >> "$out_file"
 echo -n " as const;" >> "$out_file"

--- a/script/goerli/deploy_migrator.sh
+++ b/script/goerli/deploy_migrator.sh
@@ -22,7 +22,7 @@ fi
 
 # Constructor Variables
 #
-# Comet_V2_Migrator::constructor(
+# CometMigrator::constructor(
 #   comet_ :: The Comet Ethereum mainnet USDC contract.
 #   borrowCToken_ :: The Compound II market for the borrowed token (e.g. `cUSDC`).
 #   cETH_ :: The address of the `cETH` token.
@@ -43,7 +43,7 @@ forge create \
   $etherscan_args \
   $wallet_args \
   $@ \
-  src/Comet_V2_Migrator.sol:Comet_V2_Migrator \
+  src/CometMigrator.sol:CometMigrator \
   --constructor-args \
     "$comet" \
     "$borrowCToken" \

--- a/script/mainnet/deploy_migrator.sh
+++ b/script/mainnet/deploy_migrator.sh
@@ -22,7 +22,7 @@ fi
 
 # Constructor Variables
 #
-# Comet_V2_Migrator::constructor(
+# CometMigrator::constructor(
 #   comet_ :: The Comet Ethereum mainnet USDC contract.
 #   borrowCToken_ :: The Compound II market for the borrowed token (e.g. `cUSDC`).
 #   cETH_ :: The address of the `cETH` token.
@@ -43,7 +43,7 @@ forge create \
   $etherscan_args \
   $wallet_args \
   $@ \
-  src/Comet_V2_Migrator.sol:Comet_V2_Migrator \
+  src/CometMigrator.sol:CometMigrator \
   --constructor-args \
     "$comet" \
     "$borrowCToken" \

--- a/src/CometMigrator.sol
+++ b/src/CometMigrator.sol
@@ -9,11 +9,11 @@ import "./interfaces/CTokenInterface.sol";
 import "./interfaces/CometInterface.sol";
 
 /**
- * @title Compound Migrate V2 USDC to V3 USDC
- * @notice A contract to help migrate a Compound v2 position where a user is borrowing USDC, to a similar Compound v3 position.
+ * @title Compound V3 Migrator
+ * @notice A contract to help migrate a Compound v2 position or other DeFi position into a similar Compound v3 position.
  * @author Compound
  */
-contract Comet_V2_Migrator is IUniswapV3FlashCallback {
+contract CometMigrator is IUniswapV3FlashCallback {
   error Reentrancy(uint256 loc);
   error CompoundV2Error(uint256 loc, uint256 code);
   error SweepFailure(uint256 loc);

--- a/test/CometMigrator.t.sol
+++ b/test/CometMigrator.t.sol
@@ -2,15 +2,15 @@
 pragma solidity ^0.8.13;
 
 import "forge-std/Script.sol";
-import "../src/Comet_V2_Migrator.sol";
+import "../src/CometMigrator.sol";
 import "forge-std/Test.sol";
 import "./MainnetConstants.t.sol";
 import "./Positor.t.sol";
 
-contract ContractTest is Positor {
+contract CometMigratorTest is Positor {
     event Migrated(
         address indexed user,
-        Comet_V2_Migrator.Collateral[] collateral,
+        CometMigrator.Collateral[] collateral,
         uint256 repayAmount,
         uint256 borrowAmountWithFee);
 
@@ -33,9 +33,9 @@ contract ContractTest is Positor {
         preflightChecks();
 
         // Migrate
-        Comet_V2_Migrator.Collateral[] memory collateral = new Comet_V2_Migrator.Collateral[](1);
+        CometMigrator.Collateral[] memory collateral = new CometMigrator.Collateral[](1);
         uint256 migrateAmount = amountToTokens(199e18, cUNI);
-        collateral[0] = Comet_V2_Migrator.Collateral({
+        collateral[0] = CometMigrator.Collateral({
             cToken: cUNI,
             amount: migrateAmount
         });
@@ -76,9 +76,9 @@ contract ContractTest is Positor {
         preflightChecks();
 
         // Migrate
-        Comet_V2_Migrator.Collateral[] memory collateral = new Comet_V2_Migrator.Collateral[](1);
+        CometMigrator.Collateral[] memory collateral = new CometMigrator.Collateral[](1);
         uint256 migrateAmount = amountToTokens(0.6e18, cETH);
-        collateral[0] = Comet_V2_Migrator.Collateral({
+        collateral[0] = CometMigrator.Collateral({
             cToken: cETH,
             amount: migrateAmount
         });
@@ -114,13 +114,13 @@ contract ContractTest is Positor {
         preflightChecks();
 
         // Migrate
-        Comet_V2_Migrator.Collateral[] memory collateral = new Comet_V2_Migrator.Collateral[](2);
+        CometMigrator.Collateral[] memory collateral = new CometMigrator.Collateral[](2);
         uint256 migrateAmount = amountToTokens(199e18, cUNI);
-        collateral[0] = Comet_V2_Migrator.Collateral({
+        collateral[0] = CometMigrator.Collateral({
             cToken: cUNI,
             amount: 0
         });
-        collateral[1] = Comet_V2_Migrator.Collateral({
+        collateral[1] = CometMigrator.Collateral({
             cToken: cUNI,
             amount: migrateAmount
         });
@@ -155,8 +155,8 @@ contract ContractTest is Positor {
         preflightChecks();
 
         // Migrate
-        Comet_V2_Migrator.Collateral[] memory collateral = new Comet_V2_Migrator.Collateral[](1);
-        collateral[0] = Comet_V2_Migrator.Collateral({
+        CometMigrator.Collateral[] memory collateral = new CometMigrator.Collateral[](1);
+        collateral[0] = CometMigrator.Collateral({
             cToken: cUNI,
             amount: type(uint256).max
         });
@@ -191,8 +191,8 @@ contract ContractTest is Positor {
         preflightChecks();
 
         // Migrate
-        Comet_V2_Migrator.Collateral[] memory collateral = new Comet_V2_Migrator.Collateral[](1);
-        collateral[0] = Comet_V2_Migrator.Collateral({
+        CometMigrator.Collateral[] memory collateral = new CometMigrator.Collateral[](1);
+        collateral[0] = CometMigrator.Collateral({
             cToken: cUNI,
             amount: type(uint256).max
         });
@@ -232,9 +232,9 @@ contract ContractTest is Positor {
         preflightChecks();
 
         // Migrate
-        Comet_V2_Migrator.Collateral[] memory collateral = new Comet_V2_Migrator.Collateral[](1);
+        CometMigrator.Collateral[] memory collateral = new CometMigrator.Collateral[](1);
         uint256 migrateAmount = amountToTokens(199e18, cUNI);
-        collateral[0] = Comet_V2_Migrator.Collateral({
+        collateral[0] = CometMigrator.Collateral({
             cToken: cUNI,
             amount: migrateAmount
         });
@@ -275,14 +275,14 @@ contract ContractTest is Positor {
         preflightChecks();
 
         // Migrate
-        Comet_V2_Migrator.Collateral[] memory collateral = new Comet_V2_Migrator.Collateral[](2);
+        CometMigrator.Collateral[] memory collateral = new CometMigrator.Collateral[](2);
         uint256 uniMigrateAmount = amountToTokens(199e18, cUNI);
-        collateral[0] = Comet_V2_Migrator.Collateral({
+        collateral[0] = CometMigrator.Collateral({
             cToken: cUNI,
             amount: uniMigrateAmount
         });
         uint256 ethMigrateAmount = amountToTokens(0.6e18, cETH);
-        collateral[1] = Comet_V2_Migrator.Collateral({
+        collateral[1] = CometMigrator.Collateral({
             cToken: cETH,
             amount: ethMigrateAmount
         });
@@ -321,9 +321,9 @@ contract ContractTest is Positor {
         preflightChecks();
 
         // Migrate
-        Comet_V2_Migrator.Collateral[] memory collateral = new Comet_V2_Migrator.Collateral[](1);
+        CometMigrator.Collateral[] memory collateral = new CometMigrator.Collateral[](1);
         uint256 migrateAmount = amountToTokens(199e18, cUNI);
-        collateral[0] = Comet_V2_Migrator.Collateral({
+        collateral[0] = CometMigrator.Collateral({
             cToken: cUNI,
             amount: migrateAmount
         });
@@ -360,9 +360,9 @@ contract ContractTest is Positor {
         preflightChecks();
 
         // Migrate
-        Comet_V2_Migrator.Collateral[] memory collateral = new Comet_V2_Migrator.Collateral[](1);
+        CometMigrator.Collateral[] memory collateral = new CometMigrator.Collateral[](1);
         uint256 migrateAmount = amountToTokens(0.6e18, cETH);
-        collateral[0] = Comet_V2_Migrator.Collateral({
+        collateral[0] = CometMigrator.Collateral({
             cToken: cETH,
             amount: migrateAmount
         });
@@ -371,7 +371,7 @@ contract ContractTest is Positor {
         cETH.approve(address(migrator), 0);
         comet.allow(address(migrator), true);
 
-        vm.expectRevert(Comet_V2_Migrator.CTokenTransferFailure.selector);
+        vm.expectRevert(CometMigrator.CTokenTransferFailure.selector);
         migrator.migrate(collateral, 600e6);
 
         // Check v2 balances
@@ -400,9 +400,9 @@ contract ContractTest is Positor {
         preflightChecks();
 
         // Migrate
-        Comet_V2_Migrator.Collateral[] memory collateral = new Comet_V2_Migrator.Collateral[](1);
+        CometMigrator.Collateral[] memory collateral = new CometMigrator.Collateral[](1);
         uint256 migrateAmount = amountToTokens(400e18, cUNI);
-        collateral[0] = Comet_V2_Migrator.Collateral({
+        collateral[0] = CometMigrator.Collateral({
             cToken: cUNI,
             amount: migrateAmount
         });
@@ -439,9 +439,9 @@ contract ContractTest is Positor {
         preflightChecks();
 
         // Migrate
-        Comet_V2_Migrator.Collateral[] memory collateral = new Comet_V2_Migrator.Collateral[](1);
+        CometMigrator.Collateral[] memory collateral = new CometMigrator.Collateral[](1);
         uint256 migrateAmount = amountToTokens(200e18, cETH);
-        collateral[0] = Comet_V2_Migrator.Collateral({
+        collateral[0] = CometMigrator.Collateral({
             cToken: cETH,
             amount: migrateAmount
         });
@@ -450,7 +450,7 @@ contract ContractTest is Positor {
         cETH.approve(address(migrator), type(uint256).max);
         comet.allow(address(migrator), true);
 
-        vm.expectRevert(Comet_V2_Migrator.CTokenTransferFailure.selector);
+        vm.expectRevert(CometMigrator.CTokenTransferFailure.selector);
         migrator.migrate(collateral, 600e6);
 
         // Check v2 balances
@@ -479,9 +479,9 @@ contract ContractTest is Positor {
         preflightChecks();
 
         // Migrate
-        Comet_V2_Migrator.Collateral[] memory collateral = new Comet_V2_Migrator.Collateral[](1);
+        CometMigrator.Collateral[] memory collateral = new CometMigrator.Collateral[](1);
         uint256 migrateAmount = amountToTokens(200e18, cUNI);
-        collateral[0] = Comet_V2_Migrator.Collateral({
+        collateral[0] = CometMigrator.Collateral({
             cToken: cUNI,
             amount: migrateAmount
         });
@@ -517,9 +517,9 @@ contract ContractTest is Positor {
         preflightChecks();
 
         // Migrate
-        Comet_V2_Migrator.Collateral[] memory collateral = new Comet_V2_Migrator.Collateral[](1);
+        CometMigrator.Collateral[] memory collateral = new CometMigrator.Collateral[](1);
         uint256 migrateAmount = amountToTokens(200e18, cUNI);
-        collateral[0] = Comet_V2_Migrator.Collateral({
+        collateral[0] = CometMigrator.Collateral({
             cToken: cUNI,
             amount: migrateAmount
         });
@@ -557,9 +557,9 @@ contract ContractTest is Positor {
         preflightChecks();
 
         // Migrate
-        Comet_V2_Migrator.Collateral[] memory collateral = new Comet_V2_Migrator.Collateral[](1);
+        CometMigrator.Collateral[] memory collateral = new CometMigrator.Collateral[](1);
         uint256 migrateAmount = amountToTokens(200e18, cUNI);
-        collateral[0] = Comet_V2_Migrator.Collateral({
+        collateral[0] = CometMigrator.Collateral({
             cToken: cUNI,
             amount: migrateAmount
         });
@@ -568,7 +568,7 @@ contract ContractTest is Positor {
         cUNI.approve(address(migrator), type(uint256).max);
         comet.allow(address(migrator), true);
 
-        vm.expectRevert(abi.encodeWithSelector(Comet_V2_Migrator.CompoundV2Error.selector, 0, 9));
+        vm.expectRevert(abi.encodeWithSelector(CometMigrator.CompoundV2Error.selector, 0, 9));
         migrator.migrate(collateral, 800e6);
 
         // Check v2 balances
@@ -597,8 +597,8 @@ contract ContractTest is Positor {
         preflightChecks();
 
         // Migrate
-        Comet_V2_Migrator.Collateral[] memory collateral = new Comet_V2_Migrator.Collateral[](1);
-        collateral[0] = Comet_V2_Migrator.Collateral({
+        CometMigrator.Collateral[] memory collateral = new CometMigrator.Collateral[](1);
+        collateral[0] = CometMigrator.Collateral({
             cToken: CTokenLike(address(uni)),
             amount: 0
         });
@@ -607,7 +607,7 @@ contract ContractTest is Positor {
         cUNI.approve(address(migrator), type(uint256).max);
         comet.allow(address(migrator), true);
 
-        vm.expectRevert(abi.encodeWithSelector(Comet_V2_Migrator.CompoundV2Error.selector, 0, 9));
+        vm.expectRevert(abi.encodeWithSelector(CometMigrator.CompoundV2Error.selector, 0, 9));
         migrator.migrate(collateral, 800e6);
 
         // Check v2 balances
@@ -636,8 +636,8 @@ contract ContractTest is Positor {
         preflightChecks();
 
         // Migrate
-        Comet_V2_Migrator.Collateral[] memory collateral = new Comet_V2_Migrator.Collateral[](1);
-        collateral[0] = Comet_V2_Migrator.Collateral({
+        CometMigrator.Collateral[] memory collateral = new CometMigrator.Collateral[](1);
+        collateral[0] = CometMigrator.Collateral({
             cToken: CTokenLike(0x0000000000000000000000000000000000000000),
             amount: 0
         });
@@ -646,7 +646,7 @@ contract ContractTest is Positor {
         cUNI.approve(address(migrator), type(uint256).max);
         comet.allow(address(migrator), true);
 
-        vm.expectRevert(abi.encodeWithSelector(Comet_V2_Migrator.CompoundV2Error.selector, 0, 9));
+        vm.expectRevert(abi.encodeWithSelector(CometMigrator.CompoundV2Error.selector, 0, 9));
         migrator.migrate(collateral, 800e6);
 
         // Check v2 balances
@@ -675,7 +675,7 @@ contract ContractTest is Positor {
         preflightChecks();
 
         // Migrate
-        Comet_V2_Migrator.Collateral[] memory collateral = new Comet_V2_Migrator.Collateral[](0);
+        CometMigrator.Collateral[] memory collateral = new CometMigrator.Collateral[](0);
 
         vm.startPrank(borrower);
         cUNI.approve(address(migrator), type(uint256).max);

--- a/test/MainnetConstants.t.sol
+++ b/test/MainnetConstants.t.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity ^0.8.13;
 
-import "../src/Comet_V2_Migrator.sol";
+import "../src/CometMigrator.sol";
 import "../src/vendor/@uniswap/v3-periphery/contracts/interfaces/ISwapRouter.sol";
 
 interface Comptroller {

--- a/test/Positor.t.sol
+++ b/test/Positor.t.sol
@@ -2,7 +2,7 @@
 pragma solidity ^0.8.13;
 
 import "forge-std/Script.sol";
-import "../src/Comet_V2_Migrator.sol";
+import "../src/CometMigrator.sol";
 import "forge-std/Test.sol";
 import "./MainnetConstants.t.sol";
 
@@ -19,22 +19,22 @@ contract Positor is Test, MainnetConstants {
     }
 
     mapping (CTokenLike => address) holders;
-    Comet_V2_Migrator public immutable migrator;
+    CometMigrator public immutable migrator;
 
     constructor() {
         holders[cUNI] = cHolderUni;
         holders[cETH] = cHolderEth;
 
-        console.log("Deploying Comet v2 Migrator");
-        migrator = deployCometV2Migrator();
-        console.log("Deployed Comet v2 Migrator", address(migrator));
+        console.log("Deploying Comet Migrator");
+        migrator = deployCometMigrator();
+        console.log("Deployed Comet Migrator", address(migrator));
     }
 
     function posit(Posit memory posit_) public {
         setupMigratorBorrow(posit_.borrower, posit_.positions, posit_.borrow);
     }
 
-    function setupMigratorBorrow(address borrower, Position[] memory positions, uint256 borrowAmount) internal returns (Comet_V2_Migrator) {
+    function setupMigratorBorrow(address borrower, Position[] memory positions, uint256 borrowAmount) internal returns (CometMigrator) {
         for (uint8 i = 0; i < positions.length; i++) {
             setupV2Borrows(borrower, positions[i].collateral, positions[i].amount);
         }
@@ -63,8 +63,8 @@ contract Positor is Test, MainnetConstants {
         comptroller.enterMarkets(markets);
     }
 
-    function deployCometV2Migrator() internal returns (Comet_V2_Migrator) {
-        return new Comet_V2_Migrator(
+    function deployCometMigrator() internal returns (CometMigrator) {
+        return new CometMigrator(
             comet,
             cUSDC,
             cETH,

--- a/web/Network.ts
+++ b/web/Network.ts
@@ -1,4 +1,4 @@
-import cometV2MigratorAbi from '../abis/Comet_V2_Migrator';
+import cometMigratorAbi from '../abis/CometMigrator';
 import { Contract, ContractInterface } from '@ethersproject/contracts';
 
 import mainnetV3Roots from '../node_modules/comet/deployments/mainnet/usdc/roots.json';
@@ -59,7 +59,7 @@ export type RootsV3<Network> =
 export interface NetworkConfig<Network> {
   network: Network,
   migratorAddress: string;
-  migratorAbi: typeof cometV2MigratorAbi;
+  migratorAbi: typeof cometMigratorAbi;
   cTokenNames: readonly CTokenSym<Network>[];
   cTokenAbi: [CTokenSym<Network>, string, ContractInterface][];
   rootsV2: RootsV2<Network>;
@@ -130,7 +130,7 @@ export function mainnetConfig<N extends 'mainnet'>(network: N): NetworkConfig<'m
 
   const cTokenAbi: [CTokenSym<'mainnet'>, string, ContractInterface][] = [];
   const rootsV2: RootsV2<'mainnet'> = mainnetV2Roots;
-  const migratorAbi = cometV2MigratorAbi;
+  const migratorAbi = cometMigratorAbi;
   const rootsV3: RootsV3<'mainnet'> = mainnetV3Roots;
   let v2ABI = mainnetV2Abi;
 
@@ -167,7 +167,7 @@ export function goerliConfig<N extends 'goerli'>(network: N): NetworkConfig<'goe
 
   const cTokenAbi: [CTokenSym<'goerli'>, string, ContractInterface][] = [];
   const rootsV2: RootsV2<'goerli'> = goerliV2Roots;
-  const migratorAbi = cometV2MigratorAbi;
+  const migratorAbi = cometMigratorAbi;
   const rootsV3: RootsV3<'goerli'> = goerliV3Roots;
 
   let v2ABI = goerliV2Abi;


### PR DESCRIPTION
This patch renames the contract from `Comet_V2_Migrator` to just `CometMigrator` as it's more than a single-purpose V2 migrator. We also rename this repo from `comet_v2_migrator` to `comet-migrator` to match our other repo conventions.