### PR TITLE
Fix Type Issue

### DIFF
--- a/web/lib/useWeb3.ts
+++ b/web/lib/useWeb3.ts
@@ -13,7 +13,7 @@ class RpcWeb3Provider extends JsonRpcProvider  {
 
   send(method: string, params: Array<any>): Promise<any> {
     const cache = ["eth_chainId", "eth_blockNumber"].indexOf(method) >= 0;
-    if (cache && this._cache[method]) {
+    if (cache && method in this._cache) {
       return this._cache[method];
     }
     let res = sendWeb3(this.sendRPC, method, params);
@@ -21,7 +21,7 @@ class RpcWeb3Provider extends JsonRpcProvider  {
     if (cache) {
       this._cache[method] = res;
       setTimeout(() => {
-        this._cache[method] = null as any;
+        delete this._cache[method];
       }, 0);
     }
     return res;


### PR DESCRIPTION
This patch fixes a type issue that seems to arise from tsc not properly knowing if a key is defined in a map, which could return undefined but it thinks it would always return `Promise<any>` (that should be `Promise<any> | undefined`). Anyway, we switch from `if (cache[x])` to `if (x in cache)`, which should be identical for our purposes and later instead of `cache[x] = null as any` instead we use `delete cache[x]`. I'm not 100% positive this will work, but it _should_.