### PR TITLE
Fix Test Cases

### DIFF
--- a/script/constants.sh
+++ b/script/constants.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+function set_constants() {
+  export ETH_RPC_URL=http://localhost:8545
+  export ETH_PRIVATE_KEY="0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80"
+  export fork_url="${ETHEREUM_REMOTE_NODE_MAINNET:-https://mainnet-eth.compound.finance/}"
+  export mnemonic="test test test test test test test test test test test junk"
+  export fork_block="15542274"
+
+  [ -f ".env" ] && source .env
+  [ -f ".env.local" ] && source .env.local
+}

--- a/script/playground.sh
+++ b/script/playground.sh
@@ -1,17 +1,10 @@
 #!/bin/bash
 
+. "${0%/*}/constants.sh"
+set_constants
+
 set -exo pipefail
 
-[ -f ".env" ] && source .env
-[ -f ".env.local" ] && source .env.local
-
-export ETH_RPC_URL=http://localhost:8545
-export ETH_PRIVATE_KEY="0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80"
-export fork_url="${ETHEREUM_REMOTE_NODE_MAINNET:-https://mainnet-eth.compound.finance/}"
-
-# Start Anvil fork
-mnemonic="test test test test test test test test test test test junk"
-fork_block="15542274"
 anvil --mnemonic "$mnemonic" --fork-url "$fork_url" --fork-block-number "$fork_block" --chain-id 1 --port 8545 &
 anvil_pid="$!"
 

--- a/script/test.sh
+++ b/script/test.sh
@@ -1,12 +1,8 @@
 #!/bin/bash
 
+. "${0%/*}/constants.sh"
+set_constants
+
 set -exo pipefail
 
-[ -f ".env" ] && source .env
-[ -f ".env.local" ] && source .env.local
-
-export fork_url="${ETHEREUM_REMOTE_NODE_MAINNET:-https://mainnet-eth.compound.finance/}"
-
-mnemonic="test test test test test test test test test test test junk"
-fork_block="15525659"
-forge test --mnemonic "$mnemonic" --fork-url "$fork_url" --fork-block-number "$fork_block" --etherscan-api-key "$ETHERSCAN_API_KEY" $@
+forge test --fork-url "$fork_url" --fork-block-number "$fork_block" --etherscan-api-key "$ETHERSCAN_API_KEY" $@


### PR DESCRIPTION
This patch fixes test cases, which had broken due to some changes made in a previous PR just related to the bash files. We also share constants between `tests.sh` and `playground.sh`, since they kept falling out of sync.