### PR TITLE
Add Code Coverage

### DIFF
--- a/.github/workflows/forge-coverage.yml
+++ b/.github/workflows/forge-coverage.yml
@@ -1,0 +1,43 @@
+name: Forge Coverage
+on: push
+
+env:
+  FOUNDRY_PROFILE: ci
+
+jobs:
+  check:
+    strategy:
+      fail-fast: true
+
+    name: Cover Forge Contracts
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: recursive
+
+      - name: Install Foundry
+        uses: foundry-rs/foundry-toolchain@v1
+        with:
+          version: nightly
+
+      - name: Install lcov
+        run: sudo apt-get install lcov
+
+      - name: Run Forge build
+        run: |
+          forge --version
+          forge build --sizes
+
+      - name: Run Forge coverage
+        run: |
+          script/test.sh --coverage --report lcov
+          lcov --remove lcov.info 'test/*' 'script/*' > lcov-src.info
+        env:
+          ETHEREUM_REMOTE_NODE_MAINNET: "${{ secrets.ETH_MAINNET_URL }}"
+
+      - name: Upload the coverage reports to Coveralls
+        uses: coverallsapp/github-action@master
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          path-to-lcov: ./lcov-src.info

--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,4 @@ yarn-error.log*
 *.tsbuildinfo
 
 .release
+lcov.info

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 
 # Comet Migrator
+[![Build Status](https://github.com/compound-finance/comet-migrator/workflows/Forge%20Test/badge.svg)](https://github.com/compound-finance/comet-migrator/actions?query=workflow%3A%22Forge+Test%22) [![Coverage Status](https://coveralls.io/repos/github/compound-finance/comet-migrator/badge.svg?t=TH4hUm)](https://coveralls.io/github/compound-finance/comet-migrator)
 
 The Comet Migrator is a Compound v3 Operator and Extension for migrating a position from Compound v2 and other DeFi protocols to Compound v3. The "Operator" is a smart contract which interacts with the Compound v3 Protocol on behalf of a user who approves the migrator. The "Extension" is a front-end integration into the Compound v3 interface. The Operator code is built on [Foundry](https://book.getfoundry.sh/), and the Extension code is built on [React](https://reactjs.org/) using [Vite](https://vitejs.dev/).
 
@@ -20,6 +21,20 @@ yarn web:build
 ```
 
 For the development experience, we recommend using the [Playground](#The-Playground) as described below.
+
+### Testing
+
+To test your contracts, run:
+
+```sh
+yarn forge:test
+```
+
+You can also run coverage via:
+
+```sh
+yarn forge:test --coverage
+```
 
 ### The Playground
 

--- a/script/test.sh
+++ b/script/test.sh
@@ -5,4 +5,20 @@ set_constants
 
 set -exo pipefail
 
-forge test --fork-url "$fork_url" --fork-block-number "$fork_block" --etherscan-api-key "$ETHERSCAN_API_KEY" $@
+cmd="test"
+rest=()
+
+while test $# -gt 0
+do
+  case "$1" in
+    --coverage) echo "coverage"
+      cmd="coverage"
+      ;;
+    *) echo "argument $1"
+      rest+=("$1")
+      ;;
+  esac
+  shift
+done
+
+forge "$cmd" ${args[*]} --fork-url "$fork_url" --fork-block-number "$fork_block" ${rest[*]}


### PR DESCRIPTION
This patch adds code coverage and uploads it to Coveralls in CI.

We also add badges to the README.

As per [this issue in Forge](https://github.com/foundry-rs/foundry/issues/3147#issuecomment-1278207062) we also need to trim non-`src/` files from the coverage report (since it includes `test/` as part of files to be covered, which is weird).