### PR TITLE
Add Default Eth URL

### DIFF
--- a/.env
+++ b/.env
@@ -1,3 +1,4 @@
-MAINNET_RPC_URL=https://mainnet-eth.compound.finance/
+GOERLI_RPC_URL=https://goerli-eth.compound.finance/ca406e16c11263033e1ba70218c3536f
+MAINNET_RPC_URL=https://mainnet-eth.compound.finance/ca406e16c11263033e1ba70218c3536f
 VITE_MAINNET_EXT_ADDRESS=0x1dD398C2c7fAee61eBB522c434e9f83cf3A9196b
 VITE_GOERLI_EXT_ADDRESS=0x6d1f37f5c2c6cf70871a93e439bf921c195c427f

--- a/.env.playground
+++ b/.env.playground
@@ -1,0 +1,1 @@
+MAINNET_RPC_URL=http://localhost:8545

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ To run this in embedded mode (see Embedding below), you should run the following
 
 ```sh
 # in webb3/
-VITE_WEBB3_MAINNET_URL=http://localhost:8545 VITE_COMET_MIGRATOR_SOURCE=http://localhost:5183/embedded.html yarn dev
+yarn dev --mode playground
 ```
 
 ## Comet Migrator Operator

--- a/web/Network.ts
+++ b/web/Network.ts
@@ -107,7 +107,6 @@ export function getNetworkById(chainId: number): Network | null {
 }
 
 function getMigratorAddress(network: Network): string {
-  console.log(['zzz', import.meta.env.VITE_MAINNET_EXT_ADDRESS, import.meta.env.VITE_GOERLI_EXT_ADDRESS]);
   if (network === 'mainnet') {
     return import.meta.env.VITE_MAINNET_EXT_ADDRESS;
   } else if (network === 'goerli') {


### PR DESCRIPTION
This patch uses our semi-bypass URLs (less rate-limited, but still rate-limited) by default when using this app without any custom overrides. Additionally, we make the playground always use localhost as the mainnet url.