### PR TITLE
[M-02, L-02] Sweepable funds may get stolen

### DIFF
--- a/src/CometMigratorV2.sol
+++ b/src/CometMigratorV2.sol
@@ -331,7 +331,8 @@ contract CometMigratorV2 is IUniswapV3FlashCallback {
         revert CompoundV2Error(1 + i, err);
       }
 
-      uint256 underlyingAmount = collateral.cToken.exchangeRateCurrent() * cTokenAmount / 1e18;
+      // Note: Safe to use `exchangeRateStored` as `accrue` is already called in `redeem`
+      uint256 underlyingAmount = collateral.cToken.exchangeRateStored() * cTokenAmount / 1e18;
 
       IERC20NonStandard underlying;
 

--- a/src/interfaces/CTokenInterface.sol
+++ b/src/interfaces/CTokenInterface.sol
@@ -15,6 +15,7 @@ interface CTokenLike {
   function borrowBalanceCurrent(address account) external returns (uint);
   function approve(address spender, uint256 amount) external returns (bool);
   function exchangeRateCurrent() external returns (uint);
+  function exchangeRateStored() external view returns (uint);
 }
 
 interface CErc20 is CTokenLike {

--- a/test/Tokens.t.sol
+++ b/test/Tokens.t.sol
@@ -44,6 +44,10 @@ contract LazyToken is CTokenLike {
   function exchangeRateCurrent() external virtual returns (uint) {
     return 0;
   }
+
+  function exchangeRateStored() external view virtual returns (uint) {
+    return 0;
+  }
 }
 
 contract NoRedeemToken is LazyToken {

--- a/test/TokensV2.t.sol
+++ b/test/TokensV2.t.sol
@@ -44,6 +44,10 @@ contract LazyToken is CTokenLike {
   function exchangeRateCurrent() external virtual returns (uint) {
     return 0;
   }
+
+  function exchangeRateStored() external view virtual returns (uint) {
+    return 0;
+  }
 }
 
 contract NoRedeemToken is LazyToken {


### PR DESCRIPTION
*Note: I'll hold off on updating the spec until we agree on these changes*

As noted by OZ, we are currently using `ERC20.balanceOf(migrator)` to figure out the amounts to supply/withdraw/redeem. This should be fine most of the time because the Migrator should not normally have any token balances prior to running a migration. 

To protect these funds from being swept away by a non-sweepee, I am going to explicitly define amounts instead of using `balanceOf`. However, I am still going to be preserving the use of `balanceOf` to calculate the amount to borrow from Compound III. This is because the calculation gets too complex otherwise (more details in [this comment](https://github.com/compound-finance/comet-migrator/pull/46#discussion_r1009989605)).

I also address `L-02 Inconsistent usage of approve function` in this PR because we can now approve the explicit amounts instead of `type(uint256).max` now.