### PR TITLE
Test that base asset collateral are migrated properly

### DIFF
--- a/test/MainnetConstantsV2.t.sol
+++ b/test/MainnetConstantsV2.t.sol
@@ -37,6 +37,7 @@ contract MainnetConstants {
     IWETH9 public constant weth = IWETH9(0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2);
     address public constant aHolderUni = address(0x3E0182CcC2DB35146E0529de779fB1025e8b0178);
     address public constant aHolderWeth = address(0x32e2665c8d696726c73CE28aCEe310bfac54Db85);
+    address public constant aHolderUsdc = address(0x09B21c2720A99887f817c9E7586055176868c428);
     Comptroller public constant comptroller = Comptroller(0x3d9819210A31b4961b30EF54bE2aeD79B9c9Cd3B);
     ISwapRouter public constant swapRouter = ISwapRouter(0xE592427A0AEce92De3Edee1F18E0157C05861564);
     ILendingPool public constant aaveV2LendingPool = ILendingPool(0x7d2768dE32b0b80b7a3454c06BdAc94A69DDc7A9);

--- a/test/PositorV2.t.sol
+++ b/test/PositorV2.t.sol
@@ -28,6 +28,7 @@ contract Positor is Test, MainnetConstants {
     constructor() {
         aTokenHolders[aUNI] = aHolderUni;
         aTokenHolders[aWETH] = aHolderWeth;
+        aTokenHolders[aUSDC] = aHolderUsdc;
 
         console.log("Deploying Comet Migrator");
         migrator = deployCometMigrator();


### PR DESCRIPTION
In this test, we migrate only the collateral of type base asset (USDC) while taking out a flash loan. We expect the base asset collateral to be properly migrated to Compound III, with some amount taken off to repay the flash loan interest. We expect the migrator to not retain any of the user's base asset.