### PR TITLE
Use Provider Directly

### DIFF
--- a/web/App.tsx
+++ b/web/App.tsx
@@ -314,10 +314,7 @@ export function App<N extends Network>({ rpc, web3, account, networkConfig }: Ap
     return new MulticallContract(oracleAddress, Oracle);
   }, [comptrollerRead]);
 
-  const staticProvider = useMemo(() => new StaticJsonRpcProvider(web3.connection), [web3]);
-  const ethcallProvider = useMemo(() => new Provider(staticProvider, getIdByNetwork(networkConfig.network)), [
-    staticProvider
-  ]);
+  const ethcallProvider = useMemo(() => new Provider(web3, getIdByNetwork(networkConfig.network)), [web3]);
 
   async function setTokenApproval(tokenSym: CTokenSym<Network>) {
     const tokenContract = cTokenCtxs.get(tokenSym)!;


### PR DESCRIPTION
This patch switches us to using the provider directly, instead of wrapping in a StaticJsonRpcProvider, which was ignoring the RPC-process for fetching messages and then fetching from the default address, which was incorrect. This fixes running this on prod.