### PR TITLE
fix migrator's greyed out 'migrate' button

### DIFF
--- a/web/App.tsx
+++ b/web/App.tsx
@@ -595,7 +595,7 @@ export function App<N extends Network>({ rpc, web3, account, networkConfig }: Ap
       const collateralAsset = cometData.collateralAssets.find(asset => asset.symbol === underlyingSymbol);
 
       if (!collateralAsset) {
-        return undefined;
+        continue;
       }
 
       if (transfer === 'max') {


### PR DESCRIPTION
we iterate over each (v2) ctoken to see if it's supported as a collateral asset for comet, and if it's not supported, we intend to quit migrating balances for that specific ctoken, and _continue_ on with the rest (fix the typo to change `return` to `continue`).

currently on mainnet prod (greyed out):
<img width="1404" alt="image" src="https://user-images.githubusercontent.com/15851351/203015690-86889482-6c92-477c-9efb-e17b9349f770.png">

after this change (can submit transaction to migrate):
<img width="1439" alt="Screen Shot 2022-11-21 at 3 15 51 AM" src="https://user-images.githubusercontent.com/15851351/203015843-8b8501da-39d5-4f11-9d81-2d61d448cd18.png">
