### PR TITLE
Improve Router, Kinda Sorta

### DIFF
--- a/.env.playground
+++ b/.env.playground
@@ -1,1 +1,2 @@
 MAINNET_RPC_URL=http://localhost:8545
+VITE_BYPASS_MAINNET_RPC_URL=https://mainnet-eth.compound.finance/ca406e16c11263033e1ba70218c3536f


### PR DESCRIPTION
This patch just adds a bypass to our Web3 Shim to use mainnet-eth URLs directly for the Uniswap Router since it makes like 800 bajillion calls and is somehow causing issues in Anvil. We only set this value when we're in the playground, so it won't really mess with anything else. Otherwise, it looks like the routing code is correct and now returns the correct routes.

Also note: we found a nice way to turn on the global logger, which gives us a ton of good info from Uniswap's router library, which makes it easier to debug any issues. We'll turn it off soon.