### PR TITLE
improve extension load time under conditions

### DIFF
--- a/web/App.tsx
+++ b/web/App.tsx
@@ -64,7 +64,7 @@ function usePoll(timeout: number) {
     }
     loop(1, timeout);
     return () => clearTimeout(t);
-  }, []);
+  }, [timeout]);
 
   return timer;
 }
@@ -1115,8 +1115,8 @@ export function App<N extends Network>({ rpc, web3, account, networkConfig }: Ap
 }
 
 export default ({ rpc, web3 }: AppProps) => {
-  let timer = usePoll(30000);
   const [account, setAccount] = useState<string | null>(null);
+  let timer = usePoll(!!account ? 30000 : 3000);
   const [networkConfig, setNetworkConfig] = useState<NetworkConfig<Network> | 'unsupported' | null>(null);
 
   useAsyncEffect(async () => {


### PR DESCRIPTION
if a user is not currently logged into their wallet, and on the migrator extension page they click 'Connect Wallet', it'll take up to the full polling duration (30 seconds) for the migrator extension to realize the user wallet is now connected, and start loading the app.

check for the user's wallet more frequently when they're not connected yet.
